### PR TITLE
Dependencies should use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `raknet` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:raknet, git: "git://github.com/X-Plane/elixir-raknet.git"},
+    {:raknet, git: "git://github.com/X-Plane/elixir-raknet.git", branch: "main"},
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule RakNet.MixProject do
 
   defp deps do
     [
-      {:x_util, git: "git://github.com/X-Plane/elixir-xutil.git"},
+      {:x_util, git: "git://github.com/X-Plane/elixir-xutil.git", branch: "main"},
       {:socket, "~> 0.3.13"},
       {:assertions, "~> 0.10", only: :test},
       {:credo, "~> 1.5.1", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
Hey there,
thank you for providing your work on the elixir raknet library.
I wanted to toy around with it, but was unable to depend on it in a mix application.

The problem is mix is expecting a master branch, while github is using the main branch now.
So I updated the internal dependency on X-Plane/elixir-xutil.git to use the main branch.

I also updated the installation instruction to reflect the change.

After these changes I was able to use your library.

Best regards,
Hendrik